### PR TITLE
Updated git clone in install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Python 3.10 or higher is required.
 First, clone the repository and cd into it:
 
 ```sh
-git clone https://github.com/jayceslesar/demolyzer.git
+git clone https://github.com/MegaAntiCheat/demolyzer.git
 cd demolyzer
 ```
 


### PR DESCRIPTION
Git clone download instructions went to the previous repository that has been archived. Updated it to the current one.